### PR TITLE
Add SMTP config to local development documentation

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -72,6 +72,11 @@ email:
   provider: smtp
   sender: email@updates.domain
   sender_name: Malak
+  smtp:
+    host: localhost
+    port: 9125
+    username: "user"
+    password: "pass"
   resend:
     api_key: fjfk
     webhook_secret: fufhifuji


### PR DESCRIPTION
![mlkdcs](https://github.com/user-attachments/assets/1b23f6b9-37a5-4bfc-bf0b-5f58e02ad7c7)

There's this empty value check on `cfg.Email.SMTP.Host`
